### PR TITLE
Sf movies 3

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,8 +2,5 @@
   extends: "lob",
   globals: {
     expect: false
-  },
-  rules: {
-    "prefer-arrow-callback": 0
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,5 +2,8 @@
   extends: "lob",
   globals: {
     expect: false
+  },
+  rules: {
+    "prefer-arrow-callback": 0
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 before_script:
   - npm run db:setup:user
   - npm run db:setup
-  - psql --username sfmovies_user --dbname sfmovies_test --command "CREATE EXTENSION pg_trgm;"
+  - psql --dbname sfmovies_test --command "CREATE EXTENSION pg_trgm;"
   - npm run db:reset
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
   - NODE_ENV="test"
 before_script:
   - npm run db:setup:user
-  - npm run db:setup
   - npm run db:reset
 script:
   - psql --dbname sfmovies_test --command "CREATE EXTENSION pg_trgm;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - NODE_ENV="test"
 before_script:
   - npm run db:setup:user
+  - psql --dbname sfmovies_test --command "CREATE EXTENSION pg_trgm;"
   - npm run db:reset
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - NODE_ENV="test"
 before_script:
   - npm run db:setup:user
-  - psql --command "CREATE EXTENSION pg_trgm;"
+  - psql --username sfmovies_user --dbname sfmovies_test --command "CREATE EXTENSION pg_trgm;"
   - npm run db:reset
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ env:
 before_script:
   - npm run db:setup:user
   - npm run db:setup
-  - psql --dbname sfmovies_test --command "CREATE EXTENSION pg_trgm;"
   - npm run db:reset
 script:
+  - psql --dbname sfmovies_test --command "CREATE EXTENSION pg_trgm;"
   - npm test
   - npm run enforce
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   - NODE_ENV="test"
 before_script:
   - npm run db:setup:user
-  - psql --dbname sfmovies_test --command "CREATE EXTENSION pg_trgm;"
+  - psql --command "CREATE EXTENSION pg_trgm;"
   - npm run db:reset
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - NODE_ENV="test"
 before_script:
   - npm run db:setup:user
+  - npm run db:setup
   - psql --username sfmovies_user --dbname sfmovies_test --command "CREATE EXTENSION pg_trgm;"
   - npm run db:reset
 script:

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -8,3 +8,25 @@ exports.create = (payload) => {
     return new Movie({ id: movie.id }).fetch();
   });
 };
+
+exports.findAll = (filter) => {
+  return new Movie()
+  .query(function (qb) {
+    if (filter.year !== undefined) {
+      qb.where('release_year', filter.year);
+    }
+    if (filter.from !== undefined) {
+      qb.where('release_year', '>=', filter.from);
+    }
+    if (filter.to !== undefined) {
+      qb.where('release_year', '<=', filter.to);
+    }
+    if (filter.title_exact !== undefined) {
+      qb.where('title', filter.title_exact);
+    }
+    if (filter.title_fuzzy !== undefined) {
+      qb.whereRaw('title % \''+filter.title_fuzzy+'\'');
+    }
+  })
+  .fetchAll({ withRelated: Movie.RELATED });
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -25,7 +25,7 @@ exports.findAll = (filter) => {
       qb.where('title', filter.title_exact);
     }
     if (filter.title_fuzzy !== undefined) {
-      qb.whereRaw('title % \''+filter.title_fuzzy+'\'');
+      qb.whereRaw(`title % '${filter.title_fuzzy}'`);
     }
   })
   .fetchAll({ withRelated: Movie.RELATED });

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -12,19 +12,19 @@ exports.create = (payload) => {
 exports.findAll = (filter) => {
   return new Movie()
   .query((qb) => {
-    if (filter.year !== undefined) {
+    if (filter.year) {
       qb.where('release_year', filter.year);
     }
-    if (filter.from !== undefined) {
+    if (filter.from) {
       qb.where('release_year', '>=', filter.from);
     }
-    if (filter.to !== undefined) {
+    if (filter.to) {
       qb.where('release_year', '<=', filter.to);
     }
-    if (filter.title_exact !== undefined) {
+    if (filter.title_exact) {
       qb.where('title', filter.title_exact);
     }
-    if (filter.title_fuzzy !== undefined) {
+    if (filter.title_fuzzy) {
       qb.whereRaw(`title % '${filter.title_fuzzy}'`);
     }
   })

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -11,7 +11,7 @@ exports.create = (payload) => {
 
 exports.findAll = (filter) => {
   return new Movie()
-  .query(function (qb) {
+  .query((qb) => {
     if (filter.year !== undefined) {
       qb.where('release_year', filter.year);
     }

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -16,8 +16,8 @@ exports.register = (server, options, next) => {
         payload: MovieCreateValidator
       }
     }
-  }]);
-  server.route([{
+  },
+  {
     method: 'GET',
     path: '/movies',
     config: {

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -4,6 +4,7 @@ const Controller           = require('./controller');
 const MovieCreateValidator = require('../../../validators/movies/create');
 
 exports.register = (server, options, next) => {
+
   server.route([{
     method: 'POST',
     path: '/movies',
@@ -13,6 +14,23 @@ exports.register = (server, options, next) => {
       },
       validate: {
         payload: MovieCreateValidator
+      }
+    }
+  }]);
+  server.route([{
+    method: 'GET',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.findAll(
+	  request.query.filter
+	));
+      },
+      plugins: {
+        queryFilter: {
+          enabled: true,
+          params: ['year', 'from', 'to', 'title_exact', 'title_fuzzy']
+        }
       }
     }
   }]);

--- a/lib/server.js
+++ b/lib/server.js
@@ -18,6 +18,12 @@ server.register([
     register: require('hapi-format-error'),
     options: { joiStatusCode: 422 }
   },
+  {
+    register: require('hapi-query-filter'),
+    options: {
+      defaultEnabled: true // if true plugin will be used on all routes
+    }
+  },
   require('./plugins/features/movies')
 ], (err) => {
   /* istanbul ignore if */

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1476,6 +1476,33 @@
       "resolved": "https://registry.npmjs.org/hapi-format-error/-/hapi-format-error-1.1.0.tgz",
       "integrity": "sha1-KNl/grQPGx0bYrAhXqsc3+mDu94="
     },
+    "hapi-query-filter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hapi-query-filter/-/hapi-query-filter-1.0.1.tgz",
+      "integrity": "sha1-Fo5hxKd/JQc52sZGX20Q3Cre2aw=",
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+        },
+        "isemail": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+          "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
+        },
+        "joi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-5.1.0.tgz",
+          "integrity": "sha1-FSrQfbjunGQBmX/1/SwSiWBwv1g="
+        },
+        "topo": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+          "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU="
+        }
+      }
+    },
     "has-ansi": {
       "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
@@ -2046,6 +2073,11 @@
           "dev": true
         }
       }
+    },
+    "moment": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
     "ms": {
       "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "hapi": "^16.4.3",
     "hapi-bookshelf-serializer": "^2.1.0",
     "hapi-format-error": "^1.1.0",
+    "hapi-query-filter": "^1.0.1",
     "joi": "^10.6.0",
     "knex": "^0.13.0",
     "pg": "^6.4.0"

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -26,26 +26,26 @@ describe('movie controller', () => {
 
   describe('list', () => {
 
-    beforeEach(() => {
-      return Knex.raw('TRUNCATE movies CASCADE;');
-    });
+    const movie_list = [
+      {
+        title: 'Argo',
+        release_year: 2011
+      },
+      {
+        title: 'Argo2',
+        release_year: 2012
+      },
+      {
+        title: 'Bedazzled',
+        release_year: 2007
+      }
+    ];
 
     beforeEach(() => {
-      const movie_list = [
-        {
-          title: 'Argo',
-          release_year: 2011
-        },
-        {
-          title: 'Argo2',
-          release_year: 2012
-        },
-        {
-          title: 'Bedazzled',
-          release_year: 2007
-        }
-      ];
-      return Knex('movies').insert(movie_list);
+      return Knex.raw('TRUNCATE movies CASCADE;')
+        .then(() => {
+          return Knex('movies').insert(movie_list);
+        });
     });
 
     it('List all movies. No filters specified', () => {

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -29,11 +29,11 @@ describe('movie controller', () => {
     const movie_list = [
       {
         title: 'Argo',
-        release_year: 2011
+        release_year: 2012
       },
       {
-        title: 'Argo2',
-        release_year: 2012
+        title: 'Guardians of the Galaxy',
+        release_year: 2014
       },
       {
         title: 'Bedazzled',
@@ -42,13 +42,13 @@ describe('movie controller', () => {
     ];
 
     beforeEach(() => {
-      return Knex.raw('TRUNCATE movies CASCADE;')
+      return Knex.raw('TRUNCATE movies CASCADE')
         .then(() => {
           return Knex('movies').insert(movie_list);
         });
     });
 
-    it('List all movies. No filters specified', () => {
+    it('lists all movies with no filters specified', () => {
       const filter = {};
       return Controller.findAll(filter)
       .then((movies) => {
@@ -56,19 +56,35 @@ describe('movie controller', () => {
       });
     });
 
-    it('List all movies, filtered by year ', () => {
-      const filter = { year: 2011 };
+    it('lists all movies filtered by year', () => {
+      const filter = { year: 2014 };
       return Controller.findAll(filter)
       .then((movies) => {
         expect(movies).to.have.length(1);
       });
     });
 
-    it('List all movies, filtered by range ', () => {
-      const filter = { from: 2011, to: 2012 };
+    it('lists all movies filtered by range', () => {
+      const filter = { from: 2007, to: 2012 };
       return Controller.findAll(filter)
       .then((movies) => {
         expect(movies).to.have.length(2);
+      });
+    });
+
+    it('lists all movies filtered by exact title', () => {
+      const filter = { title_exact: 'Guardians of the Galaxy' };
+      return Controller.findAll(filter)
+      .then((movies) => {
+        expect(movies).to.have.length(1);
+      });
+    });
+
+    it('lists all movies filtered by fuzzy title', () => {
+      const filter = { title_fuzzy: 'Bedazled' };
+      return Controller.findAll(filter)
+      .then((movies) => {
+        expect(movies).to.have.length(1);
       });
     });
 

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -2,6 +2,7 @@
 
 const Controller = require('../../../../lib/plugins/features/movies/controller');
 const Movie      = require('../../../../lib/models/movie');
+const Knex       = require('../../../../lib/libraries/knex');
 
 describe('movie controller', () => {
 
@@ -18,6 +19,56 @@ describe('movie controller', () => {
       })
       .then((movie) => {
         expect(movie.get('title')).to.eql(payload.title);
+      });
+    });
+
+  });
+
+  describe('list', () => {
+
+    beforeEach(() => {
+      return Knex.raw('TRUNCATE movies CASCADE;');
+    });
+
+    beforeEach(() => {
+      const movie_list = [
+        {
+          title: 'Argo',
+          release_year: 2011
+        },
+        {
+          title: 'Argo2',
+          release_year: 2012
+        },
+        {
+          title: 'Bedazzled',
+          release_year: 2007
+        }
+      ];
+      return Knex('movies').insert(movie_list);
+    });
+
+    it('List all movies. No filters specified', () => {
+      const filter = {};
+      return Controller.findAll(filter)
+      .then((movies) => {
+        expect(movies).to.have.length(3);
+      });
+    });
+
+    it('List all movies, filtered by year ', () => {
+      const filter = { year: 2011 };
+      return Controller.findAll(filter)
+      .then((movies) => {
+        expect(movies).to.have.length(1);
+      });
+    });
+
+    it('List all movies, filtered by range ', () => {
+      const filter = { from: 2011, to: 2012 };
+      return Controller.findAll(filter)
+      .then((movies) => {
+        expect(movies).to.have.length(2);
       });
     });
 

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -10,7 +10,8 @@ describe('movies integration', () => {
       return Movies.inject({
         url: '/movies',
         method: 'POST',
-        payload: { title: 'Volver', release_year : '2011' }
+        payload: { title: 'Volver',
+		   release_year: '2011' }
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
@@ -39,13 +40,13 @@ describe('movies integration', () => {
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
-	expect(response.result.length).to.be.gt(0);
-	expect(response.result[0]).to.have.all.keys([
-	  'id',
-	  'title',
-	  'release_year',
-	  'object'
-	]);
+        expect(response.result.length).to.be.gt(0);
+        expect(response.result[0]).to.have.all.keys([
+          'id',
+          'title',
+          'release_year',
+          'object'
+        ]);
       });
     });
 
@@ -56,13 +57,13 @@ describe('movies integration', () => {
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
-	expect(response.result.length).to.be.gt(0);
-	expect(response.result[0]).to.have.all.keys([
-	  'id',
-	  'title',
-	  'release_year',
-	  'object'
-	]);
+        expect(response.result.length).to.be.gt(0);
+        expect(response.result[0]).to.have.all.keys([
+          'id',
+          'title',
+          'release_year',
+          'object'
+        ]);
       });
     });
 
@@ -73,13 +74,13 @@ describe('movies integration', () => {
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
-	expect(response.result.length).to.be.gt(0);
-	expect(response.result[0]).to.have.all.keys([
-	  'id',
-	  'title',
-	  'release_year',
-	  'object'
-	]);
+        expect(response.result.length).to.be.gt(0);
+        expect(response.result[0]).to.have.all.keys([
+          'id',
+          'title',
+          'release_year',
+          'object'
+        ]);
       });
     });
 
@@ -90,13 +91,13 @@ describe('movies integration', () => {
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
-	expect(response.result.length).to.be.gt(0);
-	expect(response.result[0]).to.have.all.keys([
-	  'id',
-	  'title',
-	  'release_year',
-	  'object'
-	]);
+        expect(response.result.length).to.be.gt(0);
+        expect(response.result[0]).to.have.all.keys([
+          'id',
+          'title',
+          'release_year',
+          'object'
+        ]);
       });
     });
 

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -8,7 +8,7 @@ describe('movies integration', () => {
   describe('create', () => {
 
     beforeEach(() => {
-      return Knex.raw('TRUNCATE movies CASCADE;');
+      return Knex.raw('TRUNCATE movies CASCADE');
     });
 
     it('creates a movie', () => {
@@ -16,7 +16,7 @@ describe('movies integration', () => {
         url: '/movies',
         method: 'POST',
         payload: { title: 'Volver',
-		   release_year: '2011' }
+                   release_year: '2011' }
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
@@ -38,7 +38,7 @@ describe('movies integration', () => {
       });
     });
 
-    it('Lists movies for a given release year', () => {
+    it('lists movies for a given release year', () => {
       return Movies.inject({
         url: '/movies?year=2011',
         method: 'GET'
@@ -55,7 +55,7 @@ describe('movies integration', () => {
       });
     });
 
-    it('Lists movies for a given range of release years', () => {
+    it('lists movies for a given range of release years', () => {
       return Movies.inject({
         url: '/movies?from=2011&to=2013',
         method: 'GET'
@@ -72,18 +72,7 @@ describe('movies integration', () => {
       });
     });
 
-    it('Gets movies for a given exact title', () => {
-      return Movies.inject({
-        url: '/movies?title_exact=Volve',
-        method: 'GET'
-      })
-      .then((response) => {
-        expect(response.statusCode).to.eql(200);
-        expect(response.result.length).to.be.eq(0);
-      });
-    });
-
-    it('Gets movies for a given fuzzy title', () => {
+    it('lists movies for a given fuzzy title', () => {
       return Movies.inject({
         url: '/movies?title_fuzzy=Volve',
         method: 'GET'

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -52,6 +52,26 @@ describe('movies integration', () => {
       });
     });
 
+    it('Gets movies for a given exact title', () => {
+      return Movies.inject({
+        url: '/movies?title_exact=Argo',
+        method: 'GET'
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+      });
+    });
+
+    it('Gets movies for a given fuzzy title', () => {
+      return Movies.inject({
+        url: '/movies?title_fuzzy=Bedazled',
+        method: 'GET'
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+      });
+    });
+
   });
 
 });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,10 +1,15 @@
 'use strict';
 
 const Movies = require('../../../../lib/server');
+const Knex   = require('../../../../lib/libraries/knex');
 
 describe('movies integration', () => {
 
   describe('create', () => {
+
+    beforeEach(() => {
+      return Knex.raw('TRUNCATE movies CASCADE;');
+    });
 
     it('creates a movie', () => {
       return Movies.inject({
@@ -21,9 +26,9 @@ describe('movies integration', () => {
 
   });
 
-  describe('get', () => {
+  describe('list', () => {
 
-    it('Gets all movies', () => {
+    it('Lists all movies', () => {
       return Movies.inject({
         url: '/movies',
         method: 'GET'
@@ -33,14 +38,14 @@ describe('movies integration', () => {
       });
     });
 
-    it('Gets movies for a given release year', () => {
+    it('Lists movies for a given release year', () => {
       return Movies.inject({
         url: '/movies?year=2011',
         method: 'GET'
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
-        expect(response.result.length).to.be.gt(0);
+        expect(response.result.length).to.be.eq(1);
         expect(response.result[0]).to.have.all.keys([
           'id',
           'title',
@@ -50,14 +55,14 @@ describe('movies integration', () => {
       });
     });
 
-    it('Gets movies for a given range of release years', () => {
+    it('Lists movies for a given range of release years', () => {
       return Movies.inject({
         url: '/movies?from=2011&to=2013',
         method: 'GET'
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
-        expect(response.result.length).to.be.gt(0);
+        expect(response.result.length).to.be.eq(1);
         expect(response.result[0]).to.have.all.keys([
           'id',
           'title',
@@ -69,18 +74,12 @@ describe('movies integration', () => {
 
     it('Gets movies for a given exact title', () => {
       return Movies.inject({
-        url: '/movies?title_exact=Volver',
+        url: '/movies?title_exact=Volve',
         method: 'GET'
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
-        expect(response.result.length).to.be.gt(0);
-        expect(response.result[0]).to.have.all.keys([
-          'id',
-          'title',
-          'release_year',
-          'object'
-        ]);
+        expect(response.result.length).to.be.eq(0);
       });
     });
 
@@ -91,7 +90,7 @@ describe('movies integration', () => {
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
-        expect(response.result.length).to.be.gt(0);
+        expect(response.result.length).to.be.eq(1);
         expect(response.result[0]).to.have.all.keys([
           'id',
           'title',

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -20,4 +20,38 @@ describe('movies integration', () => {
 
   });
 
+  describe('get', () => {
+
+    it('Gets all movies', () => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'GET'
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+      });
+    });
+
+    it('Gets movies for a given release year', () => {
+      return Movies.inject({
+        url: '/movies?year=2011',
+        method: 'GET'
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+      });
+    });
+
+    it('Gets movies for a given range of release years', () => {
+      return Movies.inject({
+        url: '/movies?from=2011&to=2013',
+        method: 'GET'
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+      });
+    });
+
+  });
+
 });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -10,7 +10,7 @@ describe('movies integration', () => {
       return Movies.inject({
         url: '/movies',
         method: 'POST',
-        payload: { title: 'Volver' }
+        payload: { title: 'Volver', release_year : '2011' }
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
@@ -39,6 +39,13 @@ describe('movies integration', () => {
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
+	expect(response.result.length).to.be.gt(0);
+	expect(response.result[0]).to.have.all.keys([
+	  'id',
+	  'title',
+	  'release_year',
+	  'object'
+	]);
       });
     });
 
@@ -49,26 +56,47 @@ describe('movies integration', () => {
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
+	expect(response.result.length).to.be.gt(0);
+	expect(response.result[0]).to.have.all.keys([
+	  'id',
+	  'title',
+	  'release_year',
+	  'object'
+	]);
       });
     });
 
     it('Gets movies for a given exact title', () => {
       return Movies.inject({
-        url: '/movies?title_exact=Argo',
+        url: '/movies?title_exact=Volver',
         method: 'GET'
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
+	expect(response.result.length).to.be.gt(0);
+	expect(response.result[0]).to.have.all.keys([
+	  'id',
+	  'title',
+	  'release_year',
+	  'object'
+	]);
       });
     });
 
     it('Gets movies for a given fuzzy title', () => {
       return Movies.inject({
-        url: '/movies?title_fuzzy=Bedazled',
+        url: '/movies?title_fuzzy=Volve',
         method: 'GET'
       })
       .then((response) => {
         expect(response.statusCode).to.eql(200);
+	expect(response.result.length).to.be.gt(0);
+	expect(response.result[0]).to.have.all.keys([
+	  'id',
+	  'title',
+	  'release_year',
+	  'object'
+	]);
       });
     });
 


### PR DESCRIPTION
What: Get movies using filters by doing a  GET to /movies endpoint

Why: These changes are part of the third part of how to build your own api, involving getting results from the created movie database.

Details:
This checkin involves following changes in order to be get movie results.

- Use the hapi-query-filter dependency to be able to do db queries to the movies database.
- Add queries for getting movies by title, release_year, release year range, exact title and fuzzy title.
- Made use of pg_trgm (trigram) module for postgres to be able to perform fuzzy queries using the '%' operator.