### PR TITLE
feat(sf_movies_6): Part 2 of ZDT. Migration to backfill null values o…

### DIFF
--- a/db/migrations/20170713094702_backfill_movies_name.js
+++ b/db/migrations/20170713094702_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = function (Knex, Promise) {
+  return Knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = function (Knex, Promise) {
+  return Promise.resolve();
+};

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -11,7 +11,7 @@ module.exports = Bookshelf.Model.extend({
   serialize: function () {
     return {
       id: this.get('id'),
-      title: this.get('title') || this.get('name'),
+      title: this.get('name'),
       release_year: this.get('release_year'),
       locations: this.related('locations').map((location) => location.serialize()),
       object: 'movie'

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -47,10 +47,10 @@ exports.findAll = (filter) => {
       qb.where('release_year', '<=', filter.to);
     }
     if (filter.title_exact) {
-      qb.where('title', filter.title_exact);
+      qb.where('name', filter.title_exact);
     }
     if (filter.title_fuzzy) {
-      qb.whereRaw(`title % '${filter.title_fuzzy}'`);
+      qb.whereRaw(`name % '${filter.title_fuzzy}'`);
     }
   })
   .fetchAll({ withRelated: Movie.RELATED });


### PR DESCRIPTION
What: Write a migration to backfill all the null values of name

Why: Part of how to build your own api, involving performing ZDT migration for database schema changes.

Details:
- Write a migration to backfill all the null values of the newly added 'name' column.
- Fix queries to look for name instead of title.