### PR TITLE
Sf movies 6

### DIFF
--- a/db/migrations/20170713094702_backfill_movies_name.js
+++ b/db/migrations/20170713094702_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = function (Knex, Promise) {
+  return Knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = function (Knex, Promise) {
+  return Promise.resolve();
+};

--- a/db/migrations/20170713094702_backfill_movies_name.js
+++ b/db/migrations/20170713094702_backfill_movies_name.js
@@ -1,7 +1,7 @@
 'use strict';
 
 exports.up = function (Knex, Promise) {
-  return Knex.raw('UPDATE movies SET name = title');
+  return Knex.raw('UPDATE movies SET name = title where title IS NOT NULL');
 };
 
 exports.down = function (Knex, Promise) {

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -11,7 +11,7 @@ module.exports = Bookshelf.Model.extend({
   serialize: function () {
     return {
       id: this.get('id'),
-      title: this.get('title') || this.get('name'),
+      title: this.get('name'),
       release_year: this.get('release_year'),
       locations: this.related('locations').map((location) => location.serialize()),
       object: 'movie'

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -11,7 +11,6 @@ exports.create = (payload) => {
   Reflect.deleteProperty(payload, 'title');
   return new Movie().save(payload)
   .then((movie) => {
-    console.log(movie);
     return new Movie({ id: movie.id }).fetch();
   });
 };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -47,10 +47,10 @@ exports.findAll = (filter) => {
       qb.where('release_year', '<=', filter.to);
     }
     if (filter.title_exact) {
-      qb.where('title', filter.title_exact);
+      qb.where('name', filter.title_exact);
     }
     if (filter.title_fuzzy) {
-      qb.whereRaw(`title % '${filter.title_fuzzy}'`);
+      qb.whereRaw(`name % '${filter.title_fuzzy}'`);
     }
   })
   .fetchAll({ withRelated: Movie.RELATED });

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -11,6 +11,7 @@ exports.create = (payload) => {
   Reflect.deleteProperty(payload, 'title');
   return new Movie().save(payload)
   .then((movie) => {
+    console.log(movie);
     return new Movie({ id: movie.id }).fetch();
   });
 };

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -9,15 +9,15 @@ const Movie      = require('../../../../lib/models/movie');
 
 const MOVIE_LIST = [
   {
-    title: 'Argo',
+    name: 'Argo',
     release_year: 2012
   },
   {
-    title: 'Guardians of the Galaxy',
+    name: 'Guardians of the Galaxy',
     release_year: 2014
   },
   {
-    title: 'Bedazzled',
+    name: 'Bedazzled',
     release_year: 2007
   }
 ];
@@ -90,7 +90,7 @@ describe('movie controller', () => {
     });
 
     it('lists all movies filtered by exact title', () => {
-      const filter = { title_exact: MOVIE_LIST[1].title };
+      const filter = { title_exact: MOVIE_LIST[1].name };
       return Controller.findAll(filter)
       .then((movies) => {
         expect(movies).to.have.length(1);
@@ -111,7 +111,7 @@ describe('movie controller', () => {
 
     it('adds location to movie', () => {
       return Bluebird.all([
-        new Movie({ title: MOVIE_LIST[2].title }).fetch(),
+        new Movie({ name: MOVIE_LIST[2].name }).fetch(),
         new Location({ name: LOCATION_LIST[0].name }).fetch()
       ])
       .spread((movie, location) => {
@@ -137,7 +137,7 @@ describe('movie controller', () => {
     });
 
     it('errs when passed a non-existent location', () => {
-      return  new Movie({ title: MOVIE_LIST[2].title }).fetch()
+      return  new Movie({ name: MOVIE_LIST[2].name }).fetch()
       .then((movie) => {
         const dummyLocId = 9999;
         const payload = { id: dummyLocId };

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -9,15 +9,15 @@ const Movie    = require('../../../../lib/models/movie');
 
 const MOVIE_LIST = [
   {
-    title: 'Argo',
+    name: 'Argo',
     release_year: 2012
   },
   {
-    title: 'Guardians of the Galaxy',
+    name: 'Guardians of the Galaxy',
     release_year: 2014
   },
   {
-    title: 'Bedazzled',
+    name: 'Bedazzled',
     release_year: 2007
   }
 ];
@@ -139,7 +139,7 @@ describe('movies integration', () => {
 
     it('location to movie', () => {
       return Bluebird.all([
-        new Movie({ title: MOVIE_LIST[2].title }).fetch(),
+        new Movie({ name: MOVIE_LIST[2].name }).fetch(),
         new Location({ name: LOCATION_LIST[0].name }).fetch()
       ])
       .spread((movie, location) => {


### PR DESCRIPTION
What: Write a migration to backfill all the null values of name

Why: Part of how to build your own api, involving performing ZDT migration for database schema changes.

Details:

Write a migration to backfill all the null values of the newly added 'name' column.
Fix queries to look for name instead of title.