### PR TITLE
feat(sf_movies_7): Add not null to name and drop title

### DIFF
--- a/db/migrations/20170713153440_drop_title_from_movies.js
+++ b/db/migrations/20170713153440_drop_title_from_movies.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = function (Knex, Promise) {
+  return Knex.schema.table('movies', (table) => {
+    table.dropColumn('title');
+  })
+    .then(() => {
+      return Knex.raw('ALTER TABLE movies ALTER COLUMN name SET NOT NULL');
+    });
+};
+
+exports.down = function (Knex, Promise) {
+  return Knex.schema.table('movies', (table) => {
+    table.text('title');
+  })
+    .then(() => {
+      return Knex.raw('ALTER TABLE movies ALTER COLUMN name DROP NOT NULL');
+    });
+};

--- a/db/seeds/data/movies.json
+++ b/db/seeds/data/movies.json
@@ -1,1096 +1,1096 @@
 [{
-	  "title": "180",
-	    "release_year": 2011
+  "name": "180",
+  "release_year": 2011
 },
 {
-	  "title": "24 Hours on Craigslist",
-	    "release_year": 2005
+  "name": "24 Hours on Craigslist",
+  "release_year": 2005
 },
 {
-	  "title": "40 Days and 40 Nights",
-	    "release_year": 2002
+  "name": "40 Days and 40 Nights",
+  "release_year": 2002
 },
 {
-	  "title": "48 Hours",
-	    "release_year": 1982
+  "name": "48 Hours",
+  "release_year": 1982
 },
 {
-	  "title": "50 First Dates",
-	    "release_year": 2004
+  "name": "50 First Dates",
+  "release_year": 2004
 },
 {
-	  "title": "A Jitney Elopement",
-	    "release_year": 1915
+  "name": "A Jitney Elopement",
+  "release_year": 1915
 },
 {
-	  "title": "A Night Full of Rain",
-	    "release_year": 1978
+  "name": "A Night Full of Rain",
+  "release_year": 1978
 },
 {
-	  "title": "A Smile Like Yours",
-	    "release_year": 1997
+  "name": "A Smile Like Yours",
+  "release_year": 1997
 },
 {
-	  "title": "A View to a Kill",
-	    "release_year": 1985
+  "name": "A View to a Kill",
+  "release_year": 1985
 },
 {
-	  "title": "About a Boy",
-	    "release_year": 2014
+  "name": "About a Boy",
+  "release_year": 2014
 },
 {
-	  "title": "After the Thin Man",
-	    "release_year": 1936
+  "name": "After the Thin Man",
+  "release_year": 1936
 },
 {
-	  "title": "Age of Adaline",
-	    "release_year": 2015
+  "name": "Age of Adaline",
+  "release_year": 2015
 },
 {
-	  "title": "Alcatraz",
-	    "release_year": 2012
+  "name": "Alcatraz",
+  "release_year": 2012
 },
 {
-	  "title": "Alexander's Ragtime Band",
-	    "release_year": 1938
+  "name": "Alexander's Ragtime Band",
+  "release_year": 1938
 },
 {
-	  "title": "All About Eve",
-	    "release_year": 1950
+  "name": "All About Eve",
+  "release_year": 1950
 },
 {
-	  "title": "American Graffiti",
-	    "release_year": 1973
+  "name": "American Graffiti",
+  "release_year": 1973
 },
 {
-	  "title": "American Yearbook",
-	    "release_year": 2004
+  "name": "American Yearbook",
+  "release_year": 2004
 },
 {
-	  "title": "Americana",
-	    "release_year": 2015
+  "name": "Americana",
+  "release_year": 2015
 },
 {
-	  "title": "Another 48 Hours",
-	    "release_year": 1990
+  "name": "Another 48 Hours",
+  "release_year": 1990
 },
 {
-	  "title": "Ant-Man",
-	    "release_year": 2015
+  "name": "Ant-Man",
+  "release_year": 2015
 },
 {
-	  "title": "Around the Fire",
-	    "release_year": 1998
+  "name": "Around the Fire",
+  "release_year": 1998
 },
 {
-	  "title": "Attack of the Killer Tomatoes",
-	    "release_year": 1978
+  "name": "Attack of the Killer Tomatoes",
+  "release_year": 1978
 },
 {
-	  "title": "Babies",
-	    "release_year": 2010
+  "name": "Babies",
+  "release_year": 2010
 },
 {
-	  "title": "Barbary Coast",
-	    "release_year": 1935
+  "name": "Barbary Coast",
+  "release_year": 1935
 },
 {
-	  "title": "Basic Instinct",
-	    "release_year": 1992
+  "name": "Basic Instinct",
+  "release_year": 1992
 },
 {
-	  "title": "Beaches",
-	    "release_year": 1988
+  "name": "Beaches",
+  "release_year": 1988
 },
 {
-	  "title": "Bedazzled",
-	    "release_year": 2000
+  "name": "Bedazzled",
+  "release_year": 2000
 },
 {
-	  "title": "Bee Season",
-	    "release_year": 2005
+  "name": "Bee Season",
+  "release_year": 2005
 },
 {
-	  "title": "Bicentennial Man",
-	    "release_year": 1999
+  "name": "Bicentennial Man",
+  "release_year": 1999
 },
 {
-	  "title": "Big Eyes",
-	    "release_year": 2014
+  "name": "Big Eyes",
+  "release_year": 2014
 },
 {
-	  "title": "Big Sur",
-	    "release_year": 2013
+  "name": "Big Sur",
+  "release_year": 2013
 },
 {
-	  "title": "Big Touble in Little China",
-	    "release_year": 1986
+  "name": "Big Touble in Little China",
+  "release_year": 1986
 },
 {
-	  "title": "Birdman of Alcatraz",
-	    "release_year": 1962
+  "name": "Birdman of Alcatraz",
+  "release_year": 1962
 },
 {
-	  "title": "Blue Jasmine",
-	    "release_year": 2013
+  "name": "Blue Jasmine",
+  "release_year": 2013
 },
 {
-	  "title": "Boys and Girls",
-	    "release_year": 2000
+  "name": "Boys and Girls",
+  "release_year": 2000
 },
 {
-	  "title": "Broken-A Modern Love Story",
-	    "release_year": 2010
+  "name": "Broken-A Modern Love Story",
+  "release_year": 2010
 },
 {
-	  "title": "Bullitt",
-	    "release_year": 1968
+  "name": "Bullitt",
+  "release_year": 1968
 },
 {
-	  "title": "Burglar",
-	    "release_year": 1987
+  "name": "Burglar",
+  "release_year": 1987
 },
 {
-	  "title": "By Hook or By Crook",
-	    "release_year": 2001
+  "name": "By Hook or By Crook",
+  "release_year": 2001
 },
 {
-	  "title": "Can't Stop the Music",
-	    "release_year": 1980
+  "name": "Can't Stop the Music",
+  "release_year": 1980
 },
 {
-	  "title": "Cardinal X",
-	    "release_year": 2015
+  "name": "Cardinal X",
+  "release_year": 2015
 },
 {
-	  "title": "Casualties of War",
-	    "release_year": 1989
+  "name": "Casualties of War",
+  "release_year": 1989
 },
 {
-	  "title": "Chan is Missing",
-	    "release_year": 1982
+  "name": "Chan is Missing",
+  "release_year": 1982
 },
 {
-	  "title": "Cherish",
-	    "release_year": 2002
+  "name": "Cherish",
+  "release_year": 2002
 },
 {
-	  "title": "Chu Chu and the Philly Flash",
-	    "release_year": 1981
+  "name": "Chu Chu and the Philly Flash",
+  "release_year": 1981
 },
 {
-	  "title": "City of Angels",
-	    "release_year": 1998
+  "name": "City of Angels",
+  "release_year": 1998
 },
 {
-	  "title": "Class Action",
-	    "release_year": 1991
+  "name": "Class Action",
+  "release_year": 1991
 },
 {
-	  "title": "Common Threads: Stories From the Quilt",
-	    "release_year": 1989
+  "name": "Common Threads: Stories From the Quilt",
+  "release_year": 1989
 },
 {
-	  "title": "Confessions of a Burning Man",
-	    "release_year": 2003
+  "name": "Confessions of a Burning Man",
+  "release_year": 2003
 },
 {
-	  "title": "Copycat",
-	    "release_year": 1995
+  "name": "Copycat",
+  "release_year": 1995
 },
 {
-	  "title": "Crackers",
-	    "release_year": 1984
+  "name": "Crackers",
+  "release_year": 1984
 },
 {
-	  "title": "CSI: NY- episode 903",
-	    "release_year": 2012
+  "name": "CSI: NY- episode 903",
+  "release_year": 2012
 },
 {
-	  "title": "D.O.A",
-	    "release_year": 1950
+  "name": "D.O.A",
+  "release_year": 1950
 },
 {
-	  "title": "Dark Passage",
-	    "release_year": 1947
+  "name": "Dark Passage",
+  "release_year": 1947
 },
 {
-	  "title": "Dawn of the Planet of the Apes",
-	    "release_year": 2014
+  "name": "Dawn of the Planet of the Apes",
+  "release_year": 2014
 },
 {
-	  "title": "Days of Wine and Roses",
-	    "release_year": 1962
+  "name": "Days of Wine and Roses",
+  "release_year": 1962
 },
 {
-	  "title": "Desperate Measures",
-	    "release_year": 1998
+  "name": "Desperate Measures",
+  "release_year": 1998
 },
 {
-	  "title": "Dim Sum: A Little Bit of Heart",
-	    "release_year": 1985
+  "name": "Dim Sum: A Little Bit of Heart",
+  "release_year": 1985
 },
 {
-	  "title": "Dirty Harry",
-	    "release_year": 1971
+  "name": "Dirty Harry",
+  "release_year": 1971
 },
 {
-	  "title": "Doctor Dolittle",
-	    "release_year": 1998
+  "name": "Doctor Dolittle",
+  "release_year": 1998
 },
 {
-	  "title": "Dopamine",
-	    "release_year": 2003
+  "name": "Dopamine",
+  "release_year": 2003
 },
 {
-	  "title": "Down Periscope",
-	    "release_year": 1996
+  "name": "Down Periscope",
+  "release_year": 1996
 },
 {
-	  "title": "Dr. Dolittle 2",
-	    "release_year": 2001
+  "name": "Dr. Dolittle 2",
+  "release_year": 2001
 },
 {
-	  "title": "Dream for an Insomniac",
-	    "release_year": 1996
+  "name": "Dream for an Insomniac",
+  "release_year": 1996
 },
 {
-	  "title": "Dream with the Fishes",
-	    "release_year": 1997
+  "name": "Dream with the Fishes",
+  "release_year": 1997
 },
 {
-	  "title": "Dying Young",
-	    "release_year": 1991
+  "name": "Dying Young",
+  "release_year": 1991
 },
 {
-	  "title": "Edtv",
-	    "release_year": 1999
+  "name": "Edtv",
+  "release_year": 1999
 },
 {
-	  "title": "Escape From Alcatraz",
-	    "release_year": 1979
+  "name": "Escape From Alcatraz",
+  "release_year": 1979
 },
 {
-	  "title": "Experiment in Terror",
-	    "release_year": 1962
+  "name": "Experiment in Terror",
+  "release_year": 1962
 },
 {
-	  "title": "Faces of Death",
-	    "release_year": 1978
+  "name": "Faces of Death",
+  "release_year": 1978
 },
 {
-	  "title": "Family Plot",
-	    "release_year": 1976
+  "name": "Family Plot",
+  "release_year": 1976
 },
 {
-	  "title": "Fandom",
-	    "release_year": 2004
+  "name": "Fandom",
+  "release_year": 2004
 },
 {
-	  "title": "Fat Man and Little Boy",
-	    "release_year": 1989
+  "name": "Fat Man and Little Boy",
+  "release_year": 1989
 },
 {
-	  "title": "Fathers' Day",
-	    "release_year": 1997
+  "name": "Fathers' Day",
+  "release_year": 1997
 },
 {
-	  "title": "Fearless",
-	    "release_year": 1993
+  "name": "Fearless",
+  "release_year": 1993
 },
 {
-	  "title": "Final Analysis",
-	    "release_year": 1992
+  "name": "Final Analysis",
+  "release_year": 1992
 },
 {
-	  "title": "Flower Drum Song",
-	    "release_year": 1961
+  "name": "Flower Drum Song",
+  "release_year": 1961
 },
 {
-	  "title": "Flubber",
-	    "release_year": 1997
+  "name": "Flubber",
+  "release_year": 1997
 },
 {
-	  "title": "Forrest Gump",
-	    "release_year": 1994
+  "name": "Forrest Gump",
+  "release_year": 1994
 },
 {
-	  "title": "Foul Play",
-	    "release_year": 1978
+  "name": "Foul Play",
+  "release_year": 1978
 },
 {
-	  "title": "Freebie and the Bean",
-	    "release_year": 1974
+  "name": "Freebie and the Bean",
+  "release_year": 1974
 },
 {
-	  "title": "Gentleman Jim",
-	    "release_year": 1942
+  "name": "Gentleman Jim",
+  "release_year": 1942
 },
 {
-	  "title": "George of the Jungle",
-	    "release_year": 1997
+  "name": "George of the Jungle",
+  "release_year": 1997
 },
 {
-	  "title": "Getting Even with Dad",
-	    "release_year": 1994
+  "name": "Getting Even with Dad",
+  "release_year": 1994
 },
 {
-	  "title": "God is a Communist?* (show me heart universe)",
-	    "release_year": 2010
+  "name": "God is a Communist?* (show me heart universe)",
+  "release_year": 2010
 },
 {
-	  "title": "Godzilla",
-	    "release_year": 2014
+  "name": "Godzilla",
+  "release_year": 2014
 },
 {
-	  "title": "Golden Gate",
-	    "release_year": 1994
+  "name": "Golden Gate",
+  "release_year": 1994
 },
 {
-	  "title": "Golden Gate",
-	    "release_year": 1994
+  "name": "Golden Gate",
+  "release_year": 1994
 },
 {
-	  "title": "Greed",
-	    "release_year": 1924
+  "name": "Greed",
+  "release_year": 1924
 },
 {
-	  "title": "Groove",
-	    "release_year": 2000
+  "name": "Groove",
+  "release_year": 2000
 },
 {
-	  "title": "Guess Who's Coming to Dinner",
-	    "release_year": 1967
+  "name": "Guess Who's Coming to Dinner",
+  "release_year": 1967
 },
 {
-	  "title": "Haiku Tunnel",
-	    "release_year": 2001
+  "name": "Haiku Tunnel",
+  "release_year": 2001
 },
 {
-	  "title": "Happy Gilmore",
-	    "release_year": 1996
+  "name": "Happy Gilmore",
+  "release_year": 1996
 },
 {
-	  "title": "Hard to Hold",
-	    "release_year": 1984
+  "name": "Hard to Hold",
+  "release_year": 1984
 },
 {
-	  "title": "Harold and Maude",
-	    "release_year": 1971
+  "name": "Harold and Maude",
+  "release_year": 1971
 },
 {
-	  "title": "Heart and Souls",
-	    "release_year": 1993
+  "name": "Heart and Souls",
+  "release_year": 1993
 },
 {
-	  "title": "Heart Beat",
-	    "release_year": 1980
+  "name": "Heart Beat",
+  "release_year": 1980
 },
 {
-	  "title": "Hello Frisco, Hello",
-	    "release_year": 1943
+  "name": "Hello Frisco, Hello",
+  "release_year": 1943
 },
 {
-	  "title": "Hemingway & Gelhorn",
-	    "release_year": 2011
+  "name": "Hemingway & Gelhorn",
+  "release_year": 2011
 },
 {
-	  "title": "Herbie Rides Again",
-	    "release_year": 1974
+  "name": "Herbie Rides Again",
+  "release_year": 1974
 },
 {
-	  "title": "Hereafter",
-	    "release_year": 2010
+  "name": "Hereafter",
+  "release_year": 2010
 },
 {
-	  "title": "High Anxiety",
-	    "release_year": 1977
+  "name": "High Anxiety",
+  "release_year": 1977
 },
 {
-	  "title": "High Crimes",
-	    "release_year": 2002
+  "name": "High Crimes",
+  "release_year": 2002
 },
 {
-	  "title": "Homeward Bound II: Lost in San Francisco",
-	    "release_year": 1996
+  "name": "Homeward Bound II: Lost in San Francisco",
+  "release_year": 1996
 },
 {
-	  "title": "House of Sand and Fog",
-	    "release_year": 2003
+  "name": "House of Sand and Fog",
+  "release_year": 2003
 },
 {
-	  "title": "How Stella Got Her Groove Back",
-	    "release_year": 1998
+  "name": "How Stella Got Her Groove Back",
+  "release_year": 1998
 },
 {
-	  "title": "Hulk",
-	    "release_year": 2003
+  "name": "Hulk",
+  "release_year": 2003
 },
 {
-	  "title": "I Am Michael",
-	    "release_year": 2015
+  "name": "I Am Michael",
+  "release_year": 2015
 },
 {
-	  "title": "I Remember Mama",
-	    "release_year": 1948
+  "name": "I Remember Mama",
+  "release_year": 1948
 },
 {
-	  "title": "I's",
-	    "release_year": 2011
+  "name": "I's",
+  "release_year": 2011
 },
 {
-	  "title": "Indiana Jones and the Last Crusade",
-	    "release_year": 1989
+  "name": "Indiana Jones and the Last Crusade",
+  "release_year": 1989
 },
 {
-	  "title": "Innerspace",
-	    "release_year": 1987
+  "name": "Innerspace",
+  "release_year": 1987
 },
 {
-	  "title": "Interview With The Vampire",
-	    "release_year": 1994
+  "name": "Interview With The Vampire",
+  "release_year": 1994
 },
 {
-	  "title": "Invasion of the Body Snatchers",
-	    "release_year": 1978
+  "name": "Invasion of the Body Snatchers",
+  "release_year": 1978
 },
 {
-	  "title": "It Came From Beneath the Sea",
-	    "release_year": 1955
+  "name": "It Came From Beneath the Sea",
+  "release_year": 1955
 },
 {
-	  "title": "Jack",
-	    "release_year": 1996
+  "name": "Jack",
+  "release_year": 1996
 },
 {
-	  "title": "Jade",
-	    "release_year": 1995
+  "name": "Jade",
+  "release_year": 1995
 },
 {
-	  "title": "Jagged Edge",
-	    "release_year": 1985
+  "name": "Jagged Edge",
+  "release_year": 1985
 },
 {
-	  "title": "James and the Giant Peach",
-	    "release_year": 1996
+  "name": "James and the Giant Peach",
+  "release_year": 1996
 },
 {
-	  "title": "Joy Luck Club",
-	    "release_year": 1993
+  "name": "Joy Luck Club",
+  "release_year": 1993
 },
 {
-	  "title": "Julie and Jack",
-	    "release_year": 2003
+  "name": "Julie and Jack",
+  "release_year": 2003
 },
 {
-	  "title": "Junior",
-	    "release_year": 1994
+  "name": "Junior",
+  "release_year": 1994
 },
 {
-	  "title": "Just Like Heaven",
-	    "release_year": 2005
+  "name": "Just Like Heaven",
+  "release_year": 2005
 },
 {
-	  "title": "Just One Night",
-	    "release_year": 2000
+  "name": "Just One Night",
+  "release_year": 2000
 },
 {
-	  "title": "Kamikaze Hearts",
-	    "release_year": 1986
+  "name": "Kamikaze Hearts",
+  "release_year": 1986
 },
 {
-	  "title": "Knife Fight",
-	    "release_year": 2013
+  "name": "Knife Fight",
+  "release_year": 2013
 },
 {
-	  "title": "Live Nude Girls Unite",
-	    "release_year": 2000
+  "name": "Live Nude Girls Unite",
+  "release_year": 2000
 },
 {
-	  "title": "Looking",
-	    "release_year": 2014
+  "name": "Looking",
+  "release_year": 2014
 },
 {
-	  "title": "Love & Taxes",
-	    "release_year": 2014
+  "name": "Love & Taxes",
+  "release_year": 2014
 },
 {
-	  "title": "Magnum Force",
-	    "release_year": 1973
+  "name": "Magnum Force",
+  "release_year": 1973
 },
 {
-	  "title": "Marnie",
-	    "release_year": 1964
+  "name": "Marnie",
+  "release_year": 1964
 },
 {
-	  "title": "Maxie",
-	    "release_year": 1985
+  "name": "Maxie",
+  "release_year": 1985
 },
 {
-	  "title": "Memoirs of an Invisible Man",
-	    "release_year": 1992
+  "name": "Memoirs of an Invisible Man",
+  "release_year": 1992
 },
 {
-	  "title": "Metro",
-	    "release_year": 1997
+  "name": "Metro",
+  "release_year": 1997
 },
 {
-	  "title": "Midnight Lace",
-	    "release_year": 1960
+  "name": "Midnight Lace",
+  "release_year": 1960
 },
 {
-	  "title": "Milk",
-	    "release_year": 2008
+  "name": "Milk",
+  "release_year": 2008
 },
 {
-	  "title": "Mission (aka City of Bars)",
-	    "release_year": 2001
+  "name": "Mission (aka City of Bars)",
+  "release_year": 2001
 },
 {
-	  "title": "Mona Lisa Smile",
-	    "release_year": 2003
+  "name": "Mona Lisa Smile",
+  "release_year": 2003
 },
 {
-	  "title": "Mother",
-	    "release_year": 1996
+  "name": "Mother",
+  "release_year": 1996
 },
 {
-	  "title": "Mrs. Doubtfire",
-	    "release_year": 1993
+  "name": "Mrs. Doubtfire",
+  "release_year": 1993
 },
 {
-	  "title": "Murder in the First",
-	    "release_year": 2014
+  "name": "Murder in the First",
+  "release_year": 2014
 },
 {
-	  "title": "Murder in the First",
-	    "release_year": 1995
+  "name": "Murder in the First",
+  "release_year": 1995
 },
 {
-	  "title": "My Reality",
-	    "release_year": 2011
+  "name": "My Reality",
+  "release_year": 2011
 },
 {
-	  "title": "Need For Speed",
-	    "release_year": 2014
+  "name": "Need For Speed",
+  "release_year": 2014
 },
 {
-	  "title": "Never Die Twice",
-	    "release_year": 2001
+  "name": "Never Die Twice",
+  "release_year": 2001
 },
 {
-	  "title": "Night of Henna",
-	    "release_year": 2005
+  "name": "Night of Henna",
+  "release_year": 2005
 },
 {
-	  "title": "Nina Takes a Lover",
-	    "release_year": 1994
+  "name": "Nina Takes a Lover",
+  "release_year": 1994
 },
 {
-	  "title": "Nine Months",
-	    "release_year": 1995
+  "name": "Nine Months",
+  "release_year": 1995
 },
 {
-	  "title": "Nine to Five",
-	    "release_year": 1980
+  "name": "Nine to Five",
+  "release_year": 1980
 },
 {
-	  "title": "Nora Prentiss",
-	    "release_year": 1947
+  "name": "Nora Prentiss",
+  "release_year": 1947
 },
 {
-	  "title": "On the Beach",
-	    "release_year": 1959
+  "name": "On the Beach",
+  "release_year": 1959
 },
 {
-	  "title": "On the Road",
-	    "release_year": 2012
+  "name": "On the Road",
+  "release_year": 2012
 },
 {
-	  "title": "Pacific Heights",
-	    "release_year": 1990
+  "name": "Pacific Heights",
+  "release_year": 1990
 },
 {
-	  "title": "Pal Joey",
-	    "release_year": 1957
+  "name": "Pal Joey",
+  "release_year": 1957
 },
 {
-	  "title": "Panther",
-	    "release_year": 1995
+  "name": "Panther",
+  "release_year": 1995
 },
 {
-	  "title": "Parks and Recreation",
-	    "release_year": 2014
+  "name": "Parks and Recreation",
+  "release_year": 2014
 },
 {
-	  "title": "Patch Adams",
-	    "release_year": 1998
+  "name": "Patch Adams",
+  "release_year": 1998
 },
 {
-	  "title": "Patty Hearst",
-	    "release_year": 1988
+  "name": "Patty Hearst",
+  "release_year": 1988
 },
 {
-	  "title": "Petulia",
-	    "release_year": 1968
+  "name": "Petulia",
+  "release_year": 1968
 },
 {
-	  "title": "Phenomenon",
-	    "release_year": 1996
+  "name": "Phenomenon",
+  "release_year": 1996
 },
 {
-	  "title": "Play it Again, Sam",
-	    "release_year": 1972
+  "name": "Play it Again, Sam",
+  "release_year": 1972
 },
 {
-	  "title": "Playing Mona Lisa",
-	    "release_year": 2000
+  "name": "Playing Mona Lisa",
+  "release_year": 2000
 },
 {
-	  "title": "Pleasure of His Company",
-	    "release_year": 1961
+  "name": "Pleasure of His Company",
+  "release_year": 1961
 },
 {
-	  "title": "Point Blank",
-	    "release_year": 1967
+  "name": "Point Blank",
+  "release_year": 1967
 },
 {
-	  "title": "Pretty Woman",
-	    "release_year": 1990
+  "name": "Pretty Woman",
+  "release_year": 1990
 },
 {
-	  "title": "Psych-Out",
-	    "release_year": 1968
+  "name": "Psych-Out",
+  "release_year": 1968
 },
 {
-	  "title": "Quicksilver",
-	    "release_year": 1986
+  "name": "Quicksilver",
+  "release_year": 1986
 },
 {
-	  "title": "Quitters",
-	    "release_year": 2015
+  "name": "Quitters",
+  "release_year": 2015
 },
 {
-	  "title": "Raising Cain",
-	    "release_year": 1992
+  "name": "Raising Cain",
+  "release_year": 1992
 },
 {
-	  "title": "Red Diaper Baby",
-	    "release_year": 2004
+  "name": "Red Diaper Baby",
+  "release_year": 2004
 },
 {
-	  "title": "Red Widow",
-	    "release_year": 2013
+  "name": "Red Widow",
+  "release_year": 2013
 },
 {
-	  "title": "Rent",
-	    "release_year": 2005
+  "name": "Rent",
+  "release_year": 2005
 },
 {
-	  "title": "Rollerball",
-	    "release_year": 2002
+  "name": "Rollerball",
+  "release_year": 2002
 },
 {
-	  "title": "Romeo Must Die",
-	    "release_year": 2000
+  "name": "Romeo Must Die",
+  "release_year": 2000
 },
 {
-	  "title": "San Andreas",
-	    "release_year": 2015
+  "name": "San Andreas",
+  "release_year": 2015
 },
 {
-	  "title": "San Francisco",
-	    "release_year": 1936
+  "name": "San Francisco",
+  "release_year": 1936
 },
 {
-	  "title": "Sausalito",
-	    "release_year": 2000
+  "name": "Sausalito",
+  "release_year": 2000
 },
 {
-	  "title": "Sense8",
-	    "release_year": 2015
+  "name": "Sense8",
+  "release_year": 2015
 },
 {
-	  "title": "Serendipity",
-	    "release_year": 2001
+  "name": "Serendipity",
+  "release_year": 2001
 },
 {
-	  "title": "Serial",
-	    "release_year": 1980
+  "name": "Serial",
+  "release_year": 1980
 },
 {
-	  "title": "Seven Girlfriends",
-	    "release_year": 1999
+  "name": "Seven Girlfriends",
+  "release_year": 1999
 },
 {
-	  "title": "Shadow of the Thin Man",
-	    "release_year": 1941
+  "name": "Shadow of the Thin Man",
+  "release_year": 1941
 },
 {
-	  "title": "Shattered",
-	    "release_year": 1991
+  "name": "Shattered",
+  "release_year": 1991
 },
 {
-	  "title": "Shoot the Moon",
-	    "release_year": 1982
+  "name": "Shoot the Moon",
+  "release_year": 1982
 },
 {
-	  "title": "Sister Act",
-	    "release_year": 1992
+  "name": "Sister Act",
+  "release_year": 1992
 },
 {
-	  "title": "Sister Act 2: Back in the Habit",
-	    "release_year": 1993
+  "name": "Sister Act 2: Back in the Habit",
+  "release_year": 1993
 },
 {
-	  "title": "Smile Again, Jenny Lee",
-	    "release_year": 2015
+  "name": "Smile Again, Jenny Lee",
+  "release_year": 2015
 },
 {
-	  "title": "Sneakers",
-	    "release_year": 1992
+  "name": "Sneakers",
+  "release_year": 1992
 },
 {
-	  "title": "So I Married an Axe Murderer",
-	    "release_year": 1993
+  "name": "So I Married an Axe Murderer",
+  "release_year": 1993
 },
 {
-	  "title": "Sphere",
-	    "release_year": 1998
+  "name": "Sphere",
+  "release_year": 1998
 },
 {
-	  "title": "Star Trek II : The Wrath of Khan",
-	    "release_year": 1982
+  "name": "Star Trek II : The Wrath of Khan",
+  "release_year": 1982
 },
 {
-	  "title": "Star Trek IV: The Voyage Home",
-	    "release_year": 1986
+  "name": "Star Trek IV: The Voyage Home",
+  "release_year": 1986
 },
 {
-	  "title": "Star Trek VI: The Undiscovered Country",
-	    "release_year": 1991
+  "name": "Star Trek VI: The Undiscovered Country",
+  "release_year": 1991
 },
 {
-	  "title": "Steve Jobs",
-	    "release_year": 2015
+  "name": "Steve Jobs",
+  "release_year": 2015
 },
 {
-	  "title": "Stigmata",
-	    "release_year": 1999
+  "name": "Stigmata",
+  "release_year": 1999
 },
 {
-	  "title": "Street Music",
-	    "release_year": 1981
+  "name": "Street Music",
+  "release_year": 1981
 },
 {
-	  "title": "Sudden Fear",
-	    "release_year": 1952
+  "name": "Sudden Fear",
+  "release_year": 1952
 },
 {
-	  "title": "Sudden Impact",
-	    "release_year": 1983
+  "name": "Sudden Impact",
+  "release_year": 1983
 },
 {
-	  "title": "Summertime",
-	    "release_year": 2015
+  "name": "Summertime",
+  "release_year": 2015
 },
 {
-	  "title": "Superman",
-	    "release_year": 1978
+  "name": "Superman",
+  "release_year": 1978
 },
 {
-	  "title": "Susan Slade",
-	    "release_year": 1961
+  "name": "Susan Slade",
+  "release_year": 1961
 },
 {
-	  "title": "Sweet November",
-	    "release_year": 2001
+  "name": "Sweet November",
+  "release_year": 2001
 },
 {
-	  "title": "Swing",
-	    "release_year": 2003
+  "name": "Swing",
+  "release_year": 2003
 },
 {
-	  "title": "Swingin' Along",
-	    "release_year": 1961
+  "name": "Swingin' Along",
+  "release_year": 1961
 },
 {
-	  "title": "Take the Money and Run",
-	    "release_year": 1969
+  "name": "Take the Money and Run",
+  "release_year": 1969
 },
 {
-	  "title": "Terminator - Genisys",
-	    "release_year": 2015
+  "name": "Terminator - Genisys",
+  "release_year": 2015
 },
 {
-	  "title": "The Assassination of Richard Nixon",
-	    "release_year": 2004
+  "name": "The Assassination of Richard Nixon",
+  "release_year": 2004
 },
 {
-	  "title": "The Bachelor",
-	    "release_year": 1999
+  "name": "The Bachelor",
+  "release_year": 1999
 },
 {
-	  "title": "The Birds",
-	    "release_year": 1963
+  "name": "The Birds",
+  "release_year": 1963
 },
 {
-	  "title": "The Bridge",
-	    "release_year": 2006
+  "name": "The Bridge",
+  "release_year": 2006
 },
 {
-	  "title": "The Caine Mutiny",
-	    "release_year": 1954
+  "name": "The Caine Mutiny",
+  "release_year": 1954
 },
 {
-	  "title": "The Californians",
-	    "release_year": 2005
+  "name": "The Californians",
+  "release_year": 2005
 },
 {
-	  "title": "The Candidate",
-	    "release_year": 1972
+  "name": "The Candidate",
+  "release_year": 1972
 },
 {
-	  "title": "The Competition",
-	    "release_year": 1980
+  "name": "The Competition",
+  "release_year": 1980
 },
 {
-	  "title": "The Conversation",
-	    "release_year": 1974
+  "name": "The Conversation",
+  "release_year": 1974
 },
 {
-	  "title": "The Core",
-	    "release_year": 2003
+  "name": "The Core",
+  "release_year": 2003
 },
 {
-	  "title": "The Dead Pool",
-	    "release_year": 1988
+  "name": "The Dead Pool",
+  "release_year": 1988
 },
 {
-	  "title": "The Diary of a Teenage Girl",
-	    "release_year": 2015
+  "name": "The Diary of a Teenage Girl",
+  "release_year": 2015
 },
 {
-	  "title": "The Doctor",
-	    "release_year": 1991
+  "name": "The Doctor",
+  "release_year": 1991
 },
 {
-	  "title": "The Doors",
-	    "release_year": 1991
+  "name": "The Doors",
+  "release_year": 1991
 },
 {
-	  "title": "The Enforcer",
-	    "release_year": 1976
+  "name": "The Enforcer",
+  "release_year": 1976
 },
 {
-	  "title": "The Fan",
-	    "release_year": 1996
+  "name": "The Fan",
+  "release_year": 1996
 },
 {
-	  "title": "The Fog of War",
-	    "release_year": 2003
+  "name": "The Fog of War",
+  "release_year": 2003
 },
 {
-	  "title": "The Game",
-	    "release_year": 1997
+  "name": "The Game",
+  "release_year": 1997
 },
 {
-	  "title": "The Graduate",
-	    "release_year": 1967
+  "name": "The Graduate",
+  "release_year": 1967
 },
 {
-	  "title": "The House on Telegraph Hill",
-	    "release_year": 1951
+  "name": "The House on Telegraph Hill",
+  "release_year": 1951
 },
 {
-	  "title": "The Internship",
-	    "release_year": 2013
+  "name": "The Internship",
+  "release_year": 2013
 },
 {
-	  "title": "The Jazz Singer",
-	    "release_year": 1927
+  "name": "The Jazz Singer",
+  "release_year": 1927
 },
 {
-	  "title": "The Lady from Shanghai",
-	    "release_year": 1947
+  "name": "The Lady from Shanghai",
+  "release_year": 1947
 },
 {
-	  "title": "The Last of the Gladiators",
-	    "release_year": 1988
+  "name": "The Last of the Gladiators",
+  "release_year": 1988
 },
 {
-	  "title": "The Laughing Policeman",
-	    "release_year": 1973
+  "name": "The Laughing Policeman",
+  "release_year": 1973
 },
 {
-	  "title": "The Lineup",
-	    "release_year": 1958
+  "name": "The Lineup",
+  "release_year": 1958
 },
 {
-	  "title": "The Love Bug",
-	    "release_year": 1968
+  "name": "The Love Bug",
+  "release_year": 1968
 },
 {
-	  "title": "The Maltese Falcon",
-	    "release_year": 1941
+  "name": "The Maltese Falcon",
+  "release_year": 1941
 },
 {
-	  "title": "The Master",
-	    "release_year": 2012
+  "name": "The Master",
+  "release_year": 2012
 },
 {
-	  "title": "The Matrix",
-	    "release_year": 1999
+  "name": "The Matrix",
+  "release_year": 1999
 },
 {
-	  "title": "The Net",
-	    "release_year": 1995
+  "name": "The Net",
+  "release_year": 1995
 },
 {
-	  "title": "The Nightmare Before Christmas",
-	    "release_year": 1993
+  "name": "The Nightmare Before Christmas",
+  "release_year": 1993
 },
 {
-	  "title": "The Organization",
-	    "release_year": 1971
+  "name": "The Organization",
+  "release_year": 1971
 },
 {
-	  "title": "The Other Sister",
-	    "release_year": 1999
+  "name": "The Other Sister",
+  "release_year": 1999
 },
 {
-	  "title": "The Parent Trap",
-	    "release_year": 1998
+  "name": "The Parent Trap",
+  "release_year": 1998
 },
 {
-	  "title": "The Presidio",
-	    "release_year": 1988
+  "name": "The Presidio",
+  "release_year": 1988
 },
 {
-	  "title": "The Princess Diaries",
-	    "release_year": 2001
+  "name": "The Princess Diaries",
+  "release_year": 2001
 },
 {
-	  "title": "The Pursuit of Happyness",
-	    "release_year": 2006
+  "name": "The Pursuit of Happyness",
+  "release_year": 2006
 },
 {
-	  "title": "The Right Stuff",
-	    "release_year": 1983
+  "name": "The Right Stuff",
+  "release_year": 1983
 },
 {
-	  "title": "The Rock",
-	    "release_year": 1996
+  "name": "The Rock",
+  "release_year": 1996
 },
 {
-	  "title": "The Sweetest Thing",
-	    "release_year": 2002
+  "name": "The Sweetest Thing",
+  "release_year": 2002
 },
 {
-	  "title": "The Ten Commandments",
-	    "release_year": 1923
+  "name": "The Ten Commandments",
+  "release_year": 1923
 },
 {
-	  "title": "The Times of Harvey Milk",
-	    "release_year": 1984
+  "name": "The Times of Harvey Milk",
+  "release_year": 1984
 },
 {
-	  "title": "The Towering Inferno",
-	    "release_year": 1974
+  "name": "The Towering Inferno",
+  "release_year": 1974
 },
 {
-	  "title": "The Wedding Planner",
-	    "release_year": 2001
+  "name": "The Wedding Planner",
+  "release_year": 2001
 },
 {
-	  "title": "The Woman In Red",
-	    "release_year": 1984
+  "name": "The Woman In Red",
+  "release_year": 1984
 },
 {
-	  "title": "The Zodiac",
-	    "release_year": 2005
+  "name": "The Zodiac",
+  "release_year": 2005
 },
 {
-	  "title": "They Call Me MISTER Tibbs",
-	    "release_year": 1970
+  "name": "They Call Me MISTER Tibbs",
+  "release_year": 1970
 },
 {
-	  "title": "Thief of Hearts",
-	    "release_year": 1984
+  "name": "Thief of Hearts",
+  "release_year": 1984
 },
 {
-	  "title": "Time After Time",
-	    "release_year": 1979
+  "name": "Time After Time",
+  "release_year": 1979
 },
 {
-	  "title": "Tin Cup",
-	    "release_year": 1996
+  "name": "Tin Cup",
+  "release_year": 1996
 },
 {
-	  "title": "To the Ends of the Earth",
-	    "release_year": 1948
+  "name": "To the Ends of the Earth",
+  "release_year": 1948
 },
 {
-	  "title": "True Believer",
-	    "release_year": 1989
+  "name": "True Believer",
+  "release_year": 1989
 },
 {
-	  "title": "Tucker: The Man and His Dream",
-	    "release_year": 1988
+  "name": "Tucker: The Man and His Dream",
+  "release_year": 1988
 },
 {
-	  "title": "Tweek City",
-	    "release_year": 2005
+  "name": "Tweek City",
+  "release_year": 2005
 },
 {
-	  "title": "Twisted",
-	    "release_year": 2004
+  "name": "Twisted",
+  "release_year": 2004
 },
 {
-	  "title": "Under the Tuscan Sun",
-	    "release_year": 2003
+  "name": "Under the Tuscan Sun",
+  "release_year": 2003
 },
 {
-	  "title": "Until the End of the World",
-	    "release_year": 1991
+  "name": "Until the End of the World",
+  "release_year": 1991
 },
 {
-	  "title": "Vegas in Space",
-	    "release_year": 1992
+  "name": "Vegas in Space",
+  "release_year": 1992
 },
 {
-	  "title": "Vertigo",
-	    "release_year": 1958
+  "name": "Vertigo",
+  "release_year": 1958
 },
 {
-	  "title": "What Dreams May Come",
-	    "release_year": 1998
+  "name": "What Dreams May Come",
+  "release_year": 1998
 },
 {
-	  "title": "What the Bleep Do We Know",
-	    "release_year": 2004
+  "name": "What the Bleep Do We Know",
+  "release_year": 2004
 },
 {
-	  "title": "What's Up Doc?",
-	    "release_year": 1972
+  "name": "What's Up Doc?",
+  "release_year": 1972
 },
 {
-	  "title": "When a Man Loves a Woman",
-	    "release_year": 1994
+  "name": "When a Man Loves a Woman",
+  "release_year": 1994
 },
 {
-	  "title": "Woman on the Run",
-	    "release_year": 1950
+  "name": "Woman on the Run",
+  "release_year": 1950
 },
 {
-	  "title": "Woman on Top",
-	    "release_year": 2000
+  "name": "Woman on Top",
+  "release_year": 2000
 },
 {
-	  "title": "Yours, Mine and Ours",
-	    "release_year": 1968
+  "name": "Yours, Mine and Ours",
+  "release_year": 1968
 },
 {
-	  "title": "Zodiac",
-	    "release_year": 2007
+  "name": "Zodiac",
+  "release_year": 2007
 }]


### PR DESCRIPTION
What: Write a migration to backfill add not null to name and drop title.

Why: Part of how to build your own api, involving performing ZDT migration for database schema changes.

Details:

- Write a migration to add a not null constraint to name column and completely drop the title column.
- rename seed data columns from title to name.
